### PR TITLE
Spectre.Console 0.39.0 update

### DIFF
--- a/src/Serilog.Sinks.SpectreConsole/Serilog.Sinks.SpectreConsole.fsproj
+++ b/src/Serilog.Sinks.SpectreConsole/Serilog.Sinks.SpectreConsole.fsproj
@@ -27,7 +27,7 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog" Version="2.10.0"/>
-        <PackageReference Include="Spectre.Console" Version="0.38.0"/>
+        <PackageReference Include="Spectre.Console" Version="0.39.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Serilog.Sinks.SpectreConsole/SpectreConsole.fs
+++ b/src/Serilog.Sinks.SpectreConsole/SpectreConsole.fs
@@ -8,7 +8,7 @@ let private create (output: TextWriter) =
     AnsiConsoleSettings(
         ColorSystem = ColorSystemSupport.Detect,
         Interactive = InteractionSupport.No,
-        Out = output
+        Out = AnsiConsoleOutput(output)
     )
     |> AnsiConsole.Create
 

--- a/src/Serilog.Sinks.SpectreConsole/SpectreConsole.fs
+++ b/src/Serilog.Sinks.SpectreConsole/SpectreConsole.fs
@@ -14,7 +14,7 @@ let private create (output: TextWriter) =
 
 let render (output: TextWriter) (text) =
     let console = create(output)
-    text |> Markup |> console.Render
+    text |> Markup |> console.Write
 
 let writeException (output: TextWriter) (ex) =
     let console = create(output)


### PR DESCRIPTION
- `IAnsiConsoleOutput` abstraction was added in 0.39.0, `Out` in `AnsiConsoleSettings` now uses this abstraction instead of the direct `TextWriter` https://github.com/spectreconsole/spectre.console/commit/3e2eea730bf0f6fe4a5e336faa312b526d351079#diff-0a07f84e45cac0221fe1b88f2625f701db9181ff6af6c9882bc0849a660d0df6L25
- `IAnsiConsoleOutput` has a `TextWriter` property now
- `IAnsiConsole.Render` was marked deprecated in 0.39.0 https://github.com/spectreconsole/spectre.console/commit/20650f1e7e81d4c38f4ff3d4fb96392203912921#diff-5c93a15c006ad54ca293bf0b8e70232e1df4053b9d24cb99e01815c50732455bR16 and is advised to use `IAnsiConsole.Write`

Obviously these changes in 0.39 broke this serilog sink implementation

Changelist
- `create` now creates a new instance of `AnsiConsoleOutput` for it's `Out` prop, and uses the `TextWriter` for the `Writer` in `AnsiConsoleOutput`
- `render` now uses `console.Write` instead of `console.Render`

If there's a better way to go about making these changes, and still be able to target past Spectre.Console versions, like 0.38, without needing to build separate packages, feel free to give me some direction. I'm quite new to C#, and even newer to F#.

#2 related