### PR TITLE
Fix #8 adding support for markup in log messages

### DIFF
--- a/examples/CSharpExample/Program.cs
+++ b/examples/CSharpExample/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -31,8 +31,8 @@ namespace CSharpExample
 
             Log.Verbose("Verbose level example with {0}", "parameter");
             Log.Debug("Debug level example with {0}", "parameter");
-            Log.Information("Information level example with {0}", "parameter");
-            Log.Warning("Warning level example with {0}", "parameter");
+            Log.Information("[underline]Information[/] level example with {0}", "parameter");
+            Log.Warning("Warning [cyan]level[/] example with {0}", "parameter");
 
             try
             {

--- a/src/Serilog.Sinks.SpectreConsole/SpectreRenderer.fs
+++ b/src/Serilog.Sinks.SpectreConsole/SpectreRenderer.fs
@@ -38,6 +38,9 @@ module internal SpectreRenderer =
     let textRenderer (token: TextToken) (logEvent: LogEvent) =
         SpectreConsole.text token.Text
 
+    let markupRenderer (token: TextToken) (logEvent: LogEvent) =
+        SpectreConsole.markup token.Text
+
     let propRenderer (token: PropertyToken) (logEvent: LogEvent) =
         if logEvent.Properties.ContainsKey(token.PropertyName) then
             logEvent.Properties[token.PropertyName]
@@ -52,7 +55,7 @@ module internal SpectreRenderer =
         logEvent.MessageTemplate.Tokens
         |> Seq.map(fun token ->
             if token :? TextToken then
-                textRenderer (token :?> TextToken) logEvent
+                markupRenderer (token :?> TextToken) logEvent
             else
                 propRenderer (token :?> PropertyToken) logEvent
         )


### PR DESCRIPTION
The following small change adding a markupRender function fixes this issue and allows for markup to be used in log messages